### PR TITLE
Support Mopidy which lsinfo command is not working on playlist

### DIFF
--- a/mingus.el
+++ b/mingus.el
@@ -3227,9 +3227,12 @@ If active region, add everything between BEG and END."
          (lambda (item) (or
                             (null (cdr item))
                             (not (string-match (car item)
-                                               "file|directory|playlist"))))
-         (cdr (mingus-exec (format "lsinfo %s"
-                       (mpd-safe-string string)))))
+                                              "file|directory|playlist"))))
+         (cdr (if (string= (car item) "playlist")
+                  (mingus-exec "listplaylists")
+                (mingus-exec (format "lsinfo %s"
+                                     (mpd-safe-string string))))))
+         
         collect i)
           #'mingus-logically-less-p
       :key #'cdr)))
@@ -3362,7 +3365,7 @@ Prefix argument shows value of *mingus-point-of-insertion*, and moves there."
 (defun mingus-list-playlists ()
   (remove nil (mapcar (lambda (item)
                         (if (string= (car item) "playlist") (cdr item)))
-                      (cdr (mpd-execute-command mpd-inter-conn "lsinfo")))))
+                      (cdr (mpd-execute-command mpd-inter-conn "listplaylists")))))
 
 (defun mingus-load-playlist (&optional and-play)
   "Load an mpd playlist.

--- a/mingus.el
+++ b/mingus.el
@@ -3612,14 +3612,24 @@ Argument POS is the current position in the buffer to revert to (?)."
 			finally return list))
 		 (t
 		  (if (null as-dir)
-		      (loop for i in (cdr (mingus-exec
-                                   (format "search %s %S" type query)))
-                    if (string= (car i) "file")
-                    collect 
-                    i)
-		    (loop for i in (cdr (mingus-exec
-                                 (format "search %s %S" type query)))
-                  when 
+                      (let ((results (cdr (mingus-exec
+                                           (format "search %s %S" type query)))))
+                        (flet ((filter-results (key)
+                                       (loop for i in results
+                                             if (string= (car i) key)
+                                             collect
+                                             i)))
+                          (let ((items 
+                                 (loop for f in (filter-results "file")
+                                       for s in (filter-results "Title")
+                                       collect (cons f s))))
+                            (mapcar (lambda (item)
+                                    (if (string-match "^spotify:track.*$" (cdar item))
+                                        (cdr item)
+                                      (car item))) items))))
+                    (loop for i in (cdr (mingus-exec
+                                         (format "search %s %S" type query)))
+                          when
                   (and (string= (car i) "file"))
                   if (file-name-directory (cdr i))
                   do (add-to-list 'list

--- a/mingus.el
+++ b/mingus.el
@@ -3228,7 +3228,7 @@ If active region, add everything between BEG and END."
                             (null (cdr item))
                             (not (string-match (car item)
                                               "file|directory|playlist"))))
-         (cdr (if (string= (car item) "playlist")
+         (cdr (if (string= string "")
                   (mingus-exec "listplaylists")
                 (mingus-exec (format "lsinfo %s"
                                      (mpd-safe-string string))))))


### PR DESCRIPTION
In short, fixed problem with Mopidy server not supporting querying the playlists with `lsinfo`. We shouldn't expect that will be fixed on Mopidy server - the command is deprecated for the playlists and ~listplayllists~ should be used instead. [1]

[1] http://www.musicpd.org/doc/protocol/ch03s06.html