### PR TITLE
Fix Package Metadata for MELPA

### DIFF
--- a/mingus.el
+++ b/mingus.el
@@ -1,4 +1,4 @@
-;; mingus.el --- Time-stamp: <2011-02-04 10:12:13 sharik>
+;;; mingus.el --- Time-stamp: <2011-02-04 10:12:13 sharik>
 
 ;;            _
 ;;  _ __ ___ (_)_ __   __ _ _   _ ___
@@ -16,13 +16,16 @@
 ;; reversed order>
 
 ;; Author: Niels Giesen <pft on #emacs>
+;; URL: https://github.com/pft/mingus
+;; Package-Requires: ((libmpdee "2.1"))
 
 ;; Contributors (with patches and bug reports): Jeremie Lasalle
 ;; Ratelle, "Lexa12", Marc Zonzon, Mark Taylor, Drew Adams, Alec
 ;; Heller, "death" (github.com/death), Александр Цамутали, Maximilian
 ;; Gass and Dan King.
 
-;; Version: Open Letter to Duke, or: 0.33
+;; Version: 0.33
+;;          Or Open Letter to Duke
 ;; Latest version can be found at http://github.com/pft/mingus/
 ;; For Changes, please view http://github.com/pft/mingus/commits/master
 


### PR DESCRIPTION
Mention libmpdee dependency and alter some other package data for #9.

Is it okay that I changed the "Version" line? MELPA actually has some special way to handle non-number version lines, but I think it is better to keep it as a number.