### PR TITLE
soft-require taggit

### DIFF
--- a/mingus-stays-home.el
+++ b/mingus-stays-home.el
@@ -164,8 +164,7 @@
 (require 'cl)
 (eval-when-compile (load "cl-macs"))
 (require 'url)
-(when (featurep 'taggit)
-          (progn (require 'taggit)))
+(require 'taggit nil t)
 ;;;; {{Update Help Text}}
 
 (setq mingus-help-text


### PR DESCRIPTION
The old code did require `taggit` provided it has already been loaded (which does
nothing because it is already loaded), or if  it has not been loaded yet, then it did
not attempt to load it.