### PR TITLE
Prevent clicking whitespace from changing currently playing song

### DIFF
--- a/mingus.el
+++ b/mingus.el
@@ -1514,8 +1514,9 @@ WEBSITE:  http://github.com/pft/mingus
   (lambda (ev)
     (interactive "e")
     (when mingus-use-mouse-p
-     (mouse-set-point ev)
-     (mingus-play))))
+      (if (not (eolp))
+          (progn (mouse-set-point ev)
+                 (mingus-play))))))
 
 (define-key mingus-playlist-map
   (if (featurep 'xemacs) [button2] [mouse-2])


### PR DESCRIPTION
I'll sometimes click the Mingus buffer to switch it to the current
buffer before clicking somewhere in the playlist. To avoid changing
the currently playing song, I'll typically click somewhere to the right
or underneath the songs in the playlist, where emacs does not
highlight a song as I'm not hovering over any of them.

However, since the point is still on the end of one of the playlist
lines after clicking, I end up switching songs when I do this.

I think not switching songs if the point is at the end of a line in
this buffer is more intuitive - a user who clicks in the middle of the
line almost certainly means to change songs, whereas a user who clicks
next to or below the playlist doesn't necessarily mean to.