### PR TITLE
Support the `Name` field in playlists over `file`

### DIFF
--- a/mingus.el
+++ b/mingus.el
@@ -2462,6 +2462,7 @@ mingus-clear-cache."
            (propertize
             (mingus-truncate-string
              (or (plist-get item 'Title)
+                 (plist-get item 'Name)
                  (plist-get item 'file))
              song-width)
             'face 'mingus-song-file-face)


### PR DESCRIPTION
If you have a playlist, the current default is `Title` or `file`. This isn't great if you have a stream since you end up having a truncated URL eg.: `00.00 http://a.files.bbci.co.uk/media/live/manifesto/audio/simulcast/hls/uk/sbr_high/ak/bbc_radio_cymru.m3…`, instead of the playlist name eg.: `00.00 BBC Radio Cymru`.

This commit aims to fix this issue.

Reproduction
------------

* `.mpd/playlist/[Radio Streams].m3u`:

```
http://a.files.bbci.co.uk/media/live/manifesto/audio/simulcast/hls/uk/sbr_high/ak/bbc_radio_cymru.m3u8
```

* Output from: `M-x network-connection` to `localhost:6600`:

```
OK MPD 0.20.0
currentsong
file: http://a.files.bbci.co.uk/media/live/manifesto/audio/simulcast/hls/uk/sbr_high/ak/bbc_radio_cymru.m3u8
Name: BBC Radio Cymru
Time: 0
duration: 0.000
Pos: 12
Id: 135
OK
playlistinfo
file: http://a.files.bbci.co.uk/media/live/manifesto/audio/simulcast/hls/uk/sbr_high/ak/bbc_radio_cymru.m3u8
Name: BBC Radio Cymru
Time: 0
duration: 0.000
Pos: 12
Id: 135
OK
```

* Start mingus: `M-x mingus`.
* Load playlist: `l`, `[Radio Streams]`.
* Note `*Mingus*` browser shows: `00.00 http://a.files.bbci.co.uk/media/live/manifesto/audio/simulcast/hls/uk/sbr_high/ak/bbc_radio_cymru.m3…`.