### PR TITLE
Adding files using `addid` instead of `add`

### DIFF
--- a/mingus.el
+++ b/mingus.el
@@ -3398,7 +3398,8 @@ Actually it tries to retrieve any stream from a given url.
   (when item
     (case (mingus-get-type item)
       ((playlist) (format "load %s" (mpd-safe-string (plist-get item 'Title))))
-      ((file directory album)
+      ((file) (format "addid %s" (mpd-safe-string (plist-get item 'file))))
+      ((directory album)
        (format "add %s" (mpd-safe-string
                          (or (plist-get item 'file)
                              (plist-get item 'Title))))))))


### PR DESCRIPTION
For servers such as mopidy that provide remote file URIs in their search results (e.g., when using mopidy-gmusic, one can add full albums that look like file entries but with names of the form "gmusic:album:Bbtjr2k5632pgyabagduxcg3p4q"), adding by id is much more accurate (and for MPD is equivalent, as far as i can see).