### PR TITLE
Use display-buffer to obey display-buffer-alist rules

### DIFF
--- a/mingus.el
+++ b/mingus.el
@@ -2055,8 +2055,9 @@ details : the car of the `details' text property.
    ((get-buffer-window "*Mingus*")
     (select-window (get-buffer-window "*Mingus*")))
    (t
-    (switch-to-buffer "*Mingus*")))
-  (mingus-playlist-mode))
+    (display-buffer "*Mingus*")))
+  (with-current-buffer "*Mingus*"
+    (mingus-playlist-mode)))
 
 (defun mingus-switch-to-browser ()
   (switch-to-buffer "*Mingus Browser*")


### PR DESCRIPTION
Emacs has built-in `display-buffer-alist` for user can define custom rules. With this patch, user can define rule like this:
```elisp
(add-to-list 'display-buffer-alist '("^\\*Mingus\\*" . (display-buffer-below-selected)))
```